### PR TITLE
Add log policy hooks, fix out-of-scope variable usage

### DIFF
--- a/scripts/BACnet/main.zeek
+++ b/scripts/BACnet/main.zeek
@@ -26,6 +26,8 @@ export {
         };
     ## Event that can be handled to access the record as it is sent
     global log_bacnet: event(rec: BACnet);
+
+    global log_policy: Log::PolicyHook;
     }
 
 redef record connection += {
@@ -70,7 +72,8 @@ event zeek_init() &priority=5 {
     Log::create_stream(BACnet::Log_BACnet,
                         [$columns=BACnet,
                         $ev=log_bacnet,
-                        $path="bacnet"]);
+                        $path="bacnet",
+                        $policy=log_policy]);
     Analyzer::register_for_ports(Analyzer::ANALYZER_BACNET, ports);
     }
 

--- a/scripts/BACnet/main.zeek
+++ b/scripts/BACnet/main.zeek
@@ -347,6 +347,7 @@ event bacnet(c:connection, is_orig:bool,
                             data_index += 1;
                             len = bytestring_to_count(rest_of_data[rest_of_data_index]) % 8;
                             rest_of_data_index += 1;
+                            local property_identifier: count;
                             if (serviceChoice == 0x02) {
                                 identifier_info = bytes_to_count(len, rest_of_data[rest_of_data_index:rest_of_data_index+len]);
                                 object_type = identifier_info / 4194304;
@@ -354,7 +355,7 @@ event bacnet(c:connection, is_orig:bool,
                                 data[data_index] = fmt("object=%s", object_types[object_type]);
                                 }
                             else {
-                                local property_identifier: count = bytes_to_count(len, rest_of_data[rest_of_data_index:rest_of_data_index+len]);
+                                property_identifier = bytes_to_count(len, rest_of_data[rest_of_data_index:rest_of_data_index+len]);
                                 data[data_index] = fmt("property=%s", property_identifiers[property_identifier]);
                                 }
                             ##! don't parse list

--- a/zkg.meta
+++ b/zkg.meta
@@ -5,4 +5,4 @@ tags = zeek plugin, protocol analyzer, log writer, ics, bacnet
 description = Plugin that enables parsing of the BACnet standard building controls protocol
 depends =
   zkg >=2.0
-  zeek >=3.0.0
+  zeek >=4.0.0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*, Add log policy hook, fix out-of-scope usage warned by Zeek 4.2



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
